### PR TITLE
Consideration on index speed

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -16,7 +16,8 @@ from src.visualization.server import (
 def make_parser():
     parser = argparse.ArgumentParser("Agents and Networks in Python")
     parser.add_argument("--campus", type=str, required=True)
-    parser.add_argument("--text", action="store_true")    
+    parser.add_argument("--text", action="store_true")
+    parser.add_argument("--steps", type=int, default=10)            
     return parser
 
 
@@ -45,7 +46,7 @@ if __name__ == "__main__":
         "show_walkway": True,
         "show_lakes_and_rivers": True,
         "show_driveway": True,
-        "num_commuters": 100,
+        "num_commuters": 1000,
         "commuter_speed": campus_params[args.campus]["commuter_speed"]
     }
     map_params = {
@@ -67,7 +68,7 @@ if __name__ == "__main__":
     else:    
       model = AgentsAndNetworks(**model_params)
  
-      for i in range(10):
+      for i in range(args.steps):
         model.step()
         print(i, model.day, model.hour, model.minute)      
 

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -16,6 +16,7 @@ from src.visualization.server import (
 def make_parser():
     parser = argparse.ArgumentParser("Agents and Networks in Python")
     parser.add_argument("--campus", type=str, required=True)
+    parser.add_argument("--text", action="store_true")    
     return parser
 
 
@@ -44,16 +45,8 @@ if __name__ == "__main__":
         "show_walkway": True,
         "show_lakes_and_rivers": True,
         "show_driveway": True,
-        "num_commuters": mesa.visualization.Slider(
-            "Number of Commuters", value=50, min_value=10, max_value=150, step=10
-        ),
-        "commuter_speed": mesa.visualization.Slider(
-            "Commuter Walking Speed (m/s)",
-            value=campus_params[args.campus]["commuter_speed"],
-            min_value=0.1,
-            max_value=1.5,
-            step=0.1,
-        ),
+        "num_commuters": 100,
+        "commuter_speed": campus_params[args.campus]["commuter_speed"]
     }
     map_params = {
         "ub": {"view": [43.0022471679366, -78.785149], "zoom": 14.8},
@@ -62,10 +55,22 @@ if __name__ == "__main__":
     map_element = MapModule(
         agent_draw, **map_params[args.campus], map_height=600, map_width=600
     )
-    server = ModularServer(
-        AgentsAndNetworks,
-        [map_element, clock_element, status_chart, friendship_chart],
-        "Agents and Networks",
-        model_params,
-    )
-    server.launch()
+    
+    if not args.text:
+      server = ModularServer(
+          AgentsAndNetworks,
+          [map_element, clock_element, status_chart, friendship_chart],
+          "Agents and Networks",
+          model_params,
+      )
+      server.launch()
+    else:    
+      model = AgentsAndNetworks(**model_params)
+ 
+      for i in range(10):
+        model.step()
+        print(i, model.day, model.hour, model.minute)      
+
+      print(model.datacollector.get_model_vars_dataframe())
+    
+    

--- a/scripts/run.py
+++ b/scripts/run.py
@@ -18,6 +18,8 @@ def make_parser():
     parser.add_argument("--campus", type=str, required=True)
     parser.add_argument("--text", action="store_true")
     parser.add_argument("--steps", type=int, default=10)            
+    parser.add_argument("--commuters", type=int, default=1000)
+    parser.add_argument("--commuter_speed", type=float, default=0.9)
     return parser
 
 
@@ -33,6 +35,7 @@ if __name__ == "__main__":
 
     campus_params = {
         "ub": {"data_crs": "epsg:4326", "commuter_speed": 0.5},
+
         "gmu": {"data_crs": "epsg:2283", "commuter_speed": 0.4},
     }
     model_params = {
@@ -43,9 +46,7 @@ if __name__ == "__main__":
         "lakes_file": f"data/raw/{args.campus}/hydrop.shp",
         "rivers_file": f"data/raw/{args.campus}/hydrol.shp",
         "driveway_file": f"data/raw/{args.campus}/{data_file_prefix}_Rds.shp",
-        "show_walkway": True,
-        "show_lakes_and_rivers": True,
-        "show_driveway": True,
+        "show_driveway": True
         "num_commuters": 1000,
         "commuter_speed": campus_params[args.campus]["commuter_speed"]
     }
@@ -56,6 +57,19 @@ if __name__ == "__main__":
     map_element = MapModule(
         agent_draw, **map_params[args.campus], map_height=600, map_width=600
     )
+      model_params.update(
+          {
+            "num_commuters": mesa.visualization.Slider(
+                "Number of Commuters", value=100, min_value=10, max_value=1500, step=50
+            ),
+            "commuter_speed": mesa.visualization.Slider(
+                "Commuter Walking Speed (m/s)",
+                value=campus_params[args.campus]["commuter_speed"],
+                min_value=0.1,
+                max_value=1.5,
+                step=0.1,
+            )
+            })
     
     if not args.text:
       server = ModularServer(
@@ -64,9 +78,15 @@ if __name__ == "__main__":
           "Agents and Networks",
           model_params,
       )
+      model_params.update(
+          {
+            "num_commuters": args.commuters,
+            "commuter_speed": args.commuter_speed
+          }
+      )
       server.launch()
     else:    
-      model = AgentsAndNetworks(**model_params)
+      print(model_params)
  
       for i in range(args.steps):
         model.step()

--- a/src/model/model.py
+++ b/src/model/model.py
@@ -211,6 +211,7 @@ class AgentsAndNetworks(Model):
 
     def step(self) -> None:
         self.__update_clock()
+        if self.space.is_index_dirty: self.space._update_index()
         self.schedule.step()
         self.datacollector.collect(self)
 

--- a/src/space/campus.py
+++ b/src/space/campus.py
@@ -21,7 +21,7 @@ class Campus(FastIdxSpace):
     #_commuter_id_map: Dict[int, Commuter]
 
     def __init__(self, crs: str) -> None:
-        super().__init__(crs=crs)
+        super().__init__(crs=crs, autosync=False)
         self.homes = tuple()
         self.works = tuple()
         self.other_buildings = tuple()
@@ -58,7 +58,6 @@ class Campus(FastIdxSpace):
         self.homes = self.homes + tuple(homes)
 
     def get_commuters_by_pos(self, float_pos: FloatCoordinate) -> Set[Commuter]:
-        if self.is_index_dirty: self._create_gdf()
         return set(self.agents_at(float_pos))
         #return self._commuters_pos_map[float_pos]
 

--- a/src/space/campus.py
+++ b/src/space/campus.py
@@ -17,8 +17,8 @@ class Campus(FastIdxSpace):
     other_buildings: Tuple[Building]
     home_counter: DefaultDict[FloatCoordinate, int]
     _buildings: Dict[int, Building]
-    _commuters_pos_map: DefaultDict[FloatCoordinate, Set[Commuter]]
-    _commuter_id_map: Dict[int, Commuter]
+    #_commuters_pos_map: DefaultDict[FloatCoordinate, Set[Commuter]]
+    #_commuter_id_map: Dict[int, Commuter]
 
     def __init__(self, crs: str) -> None:
         super().__init__(crs=crs)
@@ -27,8 +27,8 @@ class Campus(FastIdxSpace):
         self.other_buildings = tuple()
         self.home_counter = defaultdict(int)
         self._buildings = dict()
-        self._commuters_pos_map = defaultdict(set)
-        self._commuter_id_map = dict()
+        #self._commuters_pos_map = defaultdict(set)
+        #self._commuter_id_map = dict()
         
         self.register_class(Commuter)
 
@@ -58,18 +58,21 @@ class Campus(FastIdxSpace):
         self.homes = self.homes + tuple(homes)
 
     def get_commuters_by_pos(self, float_pos: FloatCoordinate) -> Set[Commuter]:
-        return self._commuters_pos_map[float_pos]
+        if self.is_index_dirty: self._create_gdf()
+        return set(self.agents_at(float_pos))
+        #return self._commuters_pos_map[float_pos]
 
     def get_commuter_by_id(self, commuter_id: int) -> Commuter:
-        return self._commuter_id_map[commuter_id]
+        return self.fast_get(commuter_id)    
+        #return self._commuter_id_map[commuter_id]
 
-    def _track_commuter(self, agent: Commuter) -> None:
-        self._commuters_pos_map[(agent.geometry.x, agent.geometry.y)].add(agent)
-        self._commuter_id_map[agent.unique_id] = agent
+    #def _track_commuter(self, agent: Commuter) -> None:
+    #    self._commuters_pos_map[(agent.geometry.x, agent.geometry.y)].add(agent)
+    #    self._commuter_id_map[agent.unique_id] = agent
 
     def add_commuter(self, agent: Commuter) -> None:
         super().add_agents([agent])
-        self._track_commuter(agent)
+        #self._track_commuter(agent)
 
     def update_home_counter(
         self, old_home_pos: Optional[FloatCoordinate], new_home_pos: FloatCoordinate
@@ -79,16 +82,16 @@ class Campus(FastIdxSpace):
         self.home_counter[new_home_pos] += 1
 
     def move_commuter(self, commuter: Commuter, pos: FloatCoordinate) -> None:
-        self.__remove_commuter(commuter)
+        #self.__remove_commuter(commuter)
         self.fast_move(commuter, pos)
-        self._track_commuter(commuter)        
+        #self._track_commuter(commuter)        
         #commuter.geometry = Point(pos)
         #self.add_commuter(commuter)
 
-    def __remove_commuter(self, commuter: Commuter) -> None:
-        #super().remove_agent(commuter)
-        del self._commuter_id_map[commuter.unique_id]
-        self._commuters_pos_map[(commuter.geometry.x, commuter.geometry.y)].remove(
-            commuter
-        )
+    #def __remove_commuter(self, commuter: Commuter) -> None:
+    #    #super().remove_agent(commuter)
+    #    del self._commuter_id_map[commuter.unique_id]
+    #    self._commuters_pos_map[(commuter.geometry.x, commuter.geometry.y)].remove(
+    #        commuter
+    #    )
 

--- a/src/space/fastidx.py
+++ b/src/space/fastidx.py
@@ -1,0 +1,61 @@
+import os
+import numpy as np
+import pandas as pd
+import geopandas as gpd
+
+from shapely.geometry import Point
+from mesa_geo import GeoSpace
+from sklearn.neighbors import KDTree
+
+  
+class FastIdxSpace(GeoSpace):
+    def __init__(self, *args, **kwargs):
+      super().__init__(*args, **kwargs)
+      
+      self._fastagents = {}
+      self._gdf_is_dirty = False  
+      
+      self._filter_classes = []    
+      
+    def add_agents(self, agents):
+      toProcess = []
+      for agent in agents:
+        if type(agent) in self._filter_classes:
+          toProcess.append(agent)
+
+      for agent in toProcess: 
+        agents.remove(agent)
+        self.fast_add(agent)
+      
+      # For the remaining, use the normal GeoSpace methods
+      if len(agents) > 0: super().add_agents(agents)
+
+    def fast_get(self, aid):
+      aid=str(aid)
+      if aid in self._fastagents:
+        return self._fastagents[aid]
+
+    def fast_add(self, agent):
+      if not agent.unique_id in self._fastagents: self._fastagents[agent.unique_id] = agent
+      self._gdf_is_dirty = True
+
+    def fast_remove(self, agent, pos):
+      if not agent.unique_id in self._fastagents: return
+      del self._fastagents[agent.unique_id]
+      self._gdf_is_dirty = True
+
+    def fast_move(self, agent, pos):
+      if agent.unique_id in self._fastagents:
+        agent.geometry = Point(*pos)
+        self._gdf_is_dirty = True
+        return True
+      
+      return False
+
+######################## Fast index creation and management
+
+    def register_class(self, class_type):
+      self._filter_classes.append(class_type)
+
+      
+

--- a/src/space/fastidx.py
+++ b/src/space/fastidx.py
@@ -13,6 +13,7 @@ class FastIdxSpace(GeoSpace):
       super().__init__(*args, **kwargs)
       
       self._fastagents = {}
+      self._clear_gdf()
       self._gdf_is_dirty = False  
       
       self._filter_classes = []    
@@ -31,7 +32,6 @@ class FastIdxSpace(GeoSpace):
       if len(agents) > 0: super().add_agents(agents)
 
     def fast_get(self, aid):
-      aid=str(aid)
       if aid in self._fastagents:
         return self._fastagents[aid]
 
@@ -54,8 +54,90 @@ class FastIdxSpace(GeoSpace):
 
 ######################## Fast index creation and management
 
+    @property
+    def is_index_dirty(self):
+      return self._gdf_is_dirty
+
     def register_class(self, class_type):
       self._filter_classes.append(class_type)
 
+    def _clear_gdf(self):
+      df = pd.DataFrame(
+        {'agentid': [],
+        'geometry': []
+        })
+
+      self._agdf = gpd.GeoDataFrame(df)  
+
+    def _create_gdf(self, use_ntrees=False):
+      #self._clear_gdf()
+
+      columns = ["agentid","geometry"]
+      agent_idxs = []
+      geometries = []
+      for agent in self._fastagents.values():
+        agent_idxs.append(agent.unique_id)
+        geometries.append(agent.geometry)
+            
+      d = {
+        'agentid': agent_idxs,
+        'geometry': geometries
+        }
+      
+      self._agdf = gpd.GeoDataFrame(d, crs=self._crs)              
+
+      # Ensure that index in right gdf is formed of sequential numbers
+      self._right = self._agdf.copy().reset_index(drop=True)      
+      _right_r = np.array(self._right["geometry"].apply(
+        lambda geom: (geom.x * np.pi / 180, geom.y * np.pi / 180)).to_list()
+        )      
+      # Create tree from the candidate points
+
+      self._tree = KDTree(_right_r, leaf_size=2)    
+
+      self._gdf_is_dirty = False
+    
+          
+
+    def get_nearest(self, src_points, radius=2.0):
+      """Find nearest neighbors for all source points from a set of candidate points"""
+
+      # Find closest points and distances
+      indices = self._tree.query_radius(src_points, radius)
+
+      # Transpose to get indices into arrays
+      indices = indices.transpose().tolist()
+
+      # Return indices and distances
+      return indices
+
+    def agents_at(self, pos, max_num=5, radius=2.0):
+      res = self._agents_at(pos, max_num, radius)
+      agents = [self.fast_get(unique_id) for unique_id in res["agentid"]]
+      return agents
+
+    def _agents_at(self, pos, max_num=5, radius=2.0):
+      """Return a list of agents at given pos."""
+     
+      # Parse coordinates from points and insert them into a numpy array as RADIANS
+      left_r = np.array(
+         [ (pos[0] * np.pi / 180, pos[1] * np.pi / 180) ]
+        )
+      
+      # Find the nearest points
+      # -----------------------
+      # closest ==> index in right_gdf that corresponds to the closest point
+      
+      closest = self.get_nearest(
+        src_points=left_r, radius=radius
+        )
+      
+      # Return points from right GeoDataFrame that are closest to points in left GeoDataFrame
+      closest_points = self._right.loc[closest[0]]
+
+      # Ensure that the index corresponds the one in left_gdf
+      #closest_points = closest_points.reset_index(drop=True)
+      
+      return closest_points
       
 


### PR DESCRIPTION
Dear @wang-boyu,
thanks for sharing this nice example! I was interested in speeding it up and extending to more agents and I noticed that most of the time was spent in rebuilding the rtree index from GeoSpace for the Commuter movements, even if it seems to me you never really use it to check for neighbors.

Maybe it is possible to use a faster one based on geopandas? One could "register" a set of classes of agents that move a lot and use this other approach in parallel to the original one, which works well for more static objects.

This PR contains an initial implementations and reduces the execution time for 100 agents and 10 steps from 24s to 3s on my machine.

For now, I just dropped the index altogether, I'll work to a more complete implementation where I recreate the index only when needed as lazy as possible.

Below the profiling data from the original run and the new one.
![commuters_original](https://user-images.githubusercontent.com/524047/192319697-31bf7aa4-0546-4f7a-bbbc-1a961b5669f4.png)

![commuters_fast_noidx](https://user-images.githubusercontent.com/524047/192319783-1e74a47e-3693-4dae-b909-302fb67a7d22.png)

Let me know what do you think about that.
